### PR TITLE
Use abstract class as parent.

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -31,7 +31,7 @@ trait HasChildren
     {
         parent::registerModelEvent($event, $callback);
 
-        $childTypes = (new self)->getChildTypes();
+        $childTypes = (new static)->getChildTypes();
 
         if (static::class === self::class && $childTypes !== []) {
             // We don't want to register the callbacks that happen in the boot method of the parent, as they'll be called

--- a/tests/Features/TypeColumnCanBeAliasedTest.php
+++ b/tests/Features/TypeColumnCanBeAliasedTest.php
@@ -3,6 +3,7 @@
 namespace Parental\Tests\Features;
 
 use Parental\Tests\Models\Car;
+use Parental\Tests\Models\ChildFromAbstractParent;
 use Parental\Tests\Models\Plane;
 use Parental\Tests\Models\Vehicle;
 use Parental\Tests\TestCase;
@@ -27,5 +28,15 @@ class TypeColumnCanBeAliasedTest extends TestCase
         $car = Car::create();
 
         $this->assertEquals('car', $car->fresh()->type);
+    }
+
+    /** @test */
+    function type_column_values_can_accept_type_aliases_from_abstract_parent()
+    {
+        ChildFromAbstractParent::create(['type' => 'ChildFromAbstractParent']);
+
+        $child = ChildFromAbstractParent::all();
+
+        $this->assertInstanceOf(ChildFromAbstractParent::class, $child[0]);
     }
 }

--- a/tests/Features/TypeColumnCanBeAliasedTest.php
+++ b/tests/Features/TypeColumnCanBeAliasedTest.php
@@ -16,7 +16,7 @@ class TypeColumnCanBeAliasedTest extends TestCase
         Car::create(['type' => 'car']);
         Plane::create(['type' => Plane::class]);
 
-        $vehicles = Vehicle::all();;
+        $vehicles = Vehicle::all();
 
         $this->assertInstanceOf(Car::class, $vehicles[0]);
         $this->assertInstanceOf(Plane::class, $vehicles[1]);

--- a/tests/Features/TypeColumnCanBeAliasedTest.php
+++ b/tests/Features/TypeColumnCanBeAliasedTest.php
@@ -15,7 +15,7 @@ class TypeColumnCanBeAliasedTest extends TestCase
         Car::create(['type' => 'car']);
         Plane::create(['type' => Plane::class]);
 
-        $vehicles = Vehicle::all();
+        $vehicles = Car::all()->merge(Plane::all());
 
         $this->assertInstanceOf(Car::class, $vehicles[0]);
         $this->assertInstanceOf(Plane::class, $vehicles[1]);

--- a/tests/Features/TypeColumnCanBeAliasedTest.php
+++ b/tests/Features/TypeColumnCanBeAliasedTest.php
@@ -16,7 +16,7 @@ class TypeColumnCanBeAliasedTest extends TestCase
         Car::create(['type' => 'car']);
         Plane::create(['type' => Plane::class]);
 
-        $vehicles = Car::all()->merge(Plane::all());
+        $vehicles = Vehicle::all();;
 
         $this->assertInstanceOf(Car::class, $vehicles[0]);
         $this->assertInstanceOf(Plane::class, $vehicles[1]);

--- a/tests/Models/AbstractParent.php
+++ b/tests/Models/AbstractParent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Parental\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Parental\HasChildren;
+
+abstract class AbstractParent extends Model
+{
+    use HasChildren;
+
+    protected $fillable = [
+        'type'
+    ];
+
+    protected $childTypes = [
+        'ChildFromAbstractParent' => ChildFromAbstractParent::class,
+    ];
+
+}

--- a/tests/Models/ChildFromAbstractParent.php
+++ b/tests/Models/ChildFromAbstractParent.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Parental\Tests\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Parental\HasParent;
+
+class ChildFromAbstractParent extends AbstractParent
+{
+    use HasParent;
+    use HasFactory;
+}

--- a/tests/Models/Vehicle.php
+++ b/tests/Models/Vehicle.php
@@ -5,7 +5,7 @@ namespace Parental\Tests\Models;
 use Illuminate\Database\Eloquent\Model;
 use Parental\HasChildren;
 
-abstract class Vehicle extends Model
+class Vehicle extends Model
 {
     use HasChildren;
 

--- a/tests/Models/Vehicle.php
+++ b/tests/Models/Vehicle.php
@@ -5,7 +5,7 @@ namespace Parental\Tests\Models;
 use Illuminate\Database\Eloquent\Model;
 use Parental\HasChildren;
 
-class Vehicle extends Model
+abstract class Vehicle extends Model
 {
     use HasChildren;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -98,5 +98,11 @@ class TestCase extends BaseTestCase
             $table->string('child_node_id');
             $table->timestamps();
         });
+
+        Schema::create('abstract_parents', function ($table) {
+            $table->increments('id');
+            $table->string('type')->nullable();
+            $table->timestamps();
+        });
     }
 }

--- a/tests/factories/ChildFromAbstractParentFactory.php
+++ b/tests/factories/ChildFromAbstractParentFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Parental\Tests\Models\ChildFromAbstractParent;
+
+class ChildFromAbstractParentFactory extends Factory
+{
+    protected $model = ChildFromAbstractParent::class;
+
+
+    public function definition()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
**Problem**: Using an abstract class as a parent did work in the past, but since updating our application to laravel 10 and parental 1.3.3 we have the issue that we can't use an abstract class anymore as parent. 
(Error: Cannot instantiate abstract class...).

\Parental\HasChildren::registerModelEvent
**Changing** the self to static did do the trick. I made a quick test to show the fix.