### PR TITLE
ADD support for enum-casting of `type` field

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -235,6 +235,11 @@ trait HasChildren
     {
         $childTypes = $this->getChildTypes();
 
+        // Handling Enum casting for `type` column
+        if ($aliasOrClass instanceof \UnitEnum) {
+            $aliasOrClass = $aliasOrClass->value;
+        }
+
         if (isset($childTypes[$aliasOrClass])) {
             return $childTypes[$aliasOrClass];
         }


### PR DESCRIPTION
With this PR, users will be able to make use of this trait also if the `type` column is casted to an `Enum` instance.

In one of my projects, for example, I have the following situation, where UserType is a backed enum holding possible values.
```php
class User extends Authenticatable {
    protected $casts = [
        'type' => UserType::class,
    ];
}
```

When creating a new model instance Laravel resolves the cast providing the proper `Enum` instance, leading to an exception being thrown in `classFromAlias` where the `$aliasOrClass` is not a simple string, but the `Enum` instance.