### PR TITLE
Check existence of childTypes method

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -267,6 +267,14 @@ trait HasChildren
      */
     public function getChildTypes(): array
     {
-        return property_exists($this, 'childTypes') ? $this->childTypes : [];
+        if (method_exists($this, 'childTypes')) {
+            return $this->childTypes();
+        }
+
+        if (property_exists($this, 'childTypes')) {
+            return $this->childTypes;
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
When using _enums_ as array keys in the properties, PHP throws a syntax error, as the interpretation is considered to be dynamic. To work around this, if the values are inside a method, they will be interpreted as part of the invocation.

The method will take precedence over the property.


Before:

```php
protected $childTypes = [
  FooEnum::BAR->value => Bar::class,
  FooEnum::BAZ->value => Baz::class,
];
```

After:
```php
protected function childTypes(): array
{
  return [
    FooEnum::BAR->value => Bar::class,
    FooEnum::BAZ->value => Baz::class,
  ];
}
```