### PR TITLE
feature: throw `DomainException` insteadof `Error` with invalid `type`

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -3,6 +3,7 @@
 namespace Parental;
 
 use Closure;
+use DomainException;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -223,6 +224,10 @@ trait HasChildren
         $className = $this->classFromAlias(
             $attributes[$this->getInheritanceColumn()]
         );
+
+        if(!class_exists($className)) {
+            throw new DomainException("Class {$className} not found");
+        }
 
         return new $className((array) $attributes);
     }

--- a/tests/Features/ParentsAreAwareOfChildrenTest.php
+++ b/tests/Features/ParentsAreAwareOfChildrenTest.php
@@ -2,6 +2,7 @@
 
 namespace Parental\Tests\Features;
 
+use DomainException;
 use Parental\Tests\Models\Car;
 use Parental\Tests\Models\Driver;
 use Parental\Tests\Models\Passenger;
@@ -48,6 +49,16 @@ class ParentsAreAwareOfChildrenTest extends TestCase
         $this->assertInstanceOf(Car::class, $vehicles[0]);
         $this->assertInstanceOf(Plane::class, $vehicles[1]);
         $this->assertInstanceOf(Vehicle::class, $vehicles[2]);
+    }
+
+    /** @test */
+    function vehicle_query_builder_throw_domain_exception_with_invalid_type()
+    {
+        $this->expectException(DomainException::class);
+
+        Vehicle::create(['type' => 42]);
+
+        $vehicles = Vehicle::query()->get();
     }
 
     /** @test */


### PR DESCRIPTION
## detail

Currently, `\Error` is thrown when retrieving a record in which an unknown value is set in the identification column `type`.

I think it's reasonable behavior to throw "something" when we try to get a invalid record, but if we need to catch it on the user side, `\Error` is too wide and inconvenient.

So I made it throw a `\DomainException` with a narrower scope.

## consideration

It may be better to throw your own exceptions prepared by the library instead of PHP's built-in exceptions.

However, since there was no corresponding part in the existing implementation, I didn't know the best way to do it, so I'm using DomainException now.

Please let me know if I should fix it. I will of course fix it if necessary.