### PR TITLE
Support ObservedBy attribute in parent class

### DIFF
--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -40,6 +40,9 @@ trait HasParent
                 $query->where($query->getModel()->getTable() . '.' . $instance->getInheritanceColumn(), $instance->classToAlias(get_class($instance)));
             }
         });
+
+        $parentObservedBy = (new static)->getParentClass()::resolveObserveAttributes();
+        static::observe($parentObservedBy);
     }
 
     public function parentHasHasChildrenTrait(): bool

--- a/src/HasParent.php
+++ b/src/HasParent.php
@@ -41,8 +41,11 @@ trait HasParent
             }
         });
 
-        $parentObservedBy = (new static)->getParentClass()::resolveObserveAttributes();
-        static::observe($parentObservedBy);
+        
+        if (method_exists(static::class, 'resolveObserveAttributes')) {
+            $parentObservedBy = (new static)->getParentClass()::resolveObserveAttributes();
+            static::observe($parentObservedBy);
+        }
     }
 
     public function parentHasHasChildrenTrait(): bool


### PR DESCRIPTION
Laravel recently added support for the ObservedBy attribute as a way of registering observers for eloquent models. This pull request adds support for the use of ObservedBy in both the child and parent classes.