### PR TITLE
feat: add `toChildModel` method

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -246,6 +246,16 @@ trait HasChildren
     }
 
     /**
+     * Create a child model from the current instance.
+     *
+     * @return static
+     */
+    public function toChildModel(): self
+    {
+        return $this->newInstance($this->getAttributes(), $this->exists);
+    }
+
+    /**
      * @return mixed
      */
     protected function getChildModel(array $attributes)


### PR DESCRIPTION
It would be great if there was a `toChildModel` method that I can easily use to convert parent models to child models. Please let me know if you like the idea so I can create corresponding tests. 