### PR TITLE
fix: avoid mass assignment

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -254,6 +254,12 @@ trait HasChildren
             $attributes[$this->getInheritanceColumn()]
         );
 
-        return new $className((array) $attributes);
+        $childModel = new $className();
+    
+        foreach ($attributes as $key => $value) {
+            $childModel->setAttribute($key, $value);
+        }
+    
+        return $childModel;
     }
 }


### PR DESCRIPTION
I would like to avoid setting `$fillable` at all. This approach would set attributes one by one and does the same thing without causing any exception in strict mode.