### PR TITLE
possible fix for double event registration in child models when calling events from parent trait use

### DIFF
--- a/src/HasChildren.php
+++ b/src/HasChildren.php
@@ -16,6 +16,11 @@ trait HasChildren
     protected static $parentBootMethods;
 
     /**
+     * @var array
+     */
+    protected static $parentClasses;
+
+    /**
      * @var bool
      */
     protected $hasChildren = true;
@@ -57,11 +62,21 @@ trait HasChildren
             self::$parentBootMethods = array_flip(self::$parentBootMethods);
         }
 
-        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $trace) {
-            $class = isset($trace['class']) ? $trace['class'] : null;
-            $function = isset($trace['function']) ? $trace['function'] : '';
+        if (! isset(self::$parentClasses)) {
+            foreach (class_parents(self::class) as $parent) {
+                self::$parentClasses[$parent] = true;
+            }
+        }
 
-            if ($class === self::class && isset(self::$parentBootMethods[$function])) {
+        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $trace) {
+            if (! isset($trace['class']) || ! isset($trace['function'])) {
+                continue;
+            }
+
+            $class = $trace['class'];
+            $function = $trace['function'];
+
+            if (($class === self::class || isset(self::$parentClasses[$class])) && isset(self::$parentBootMethods[$function])) {
                 return true;
             }
         }

--- a/tests/Features/ParentsObserveChildrenTest.php
+++ b/tests/Features/ParentsObserveChildrenTest.php
@@ -2,7 +2,10 @@
 
 namespace Parental\Tests\Features;
 
+use Parental\Tests\Models\Animal;
 use Parental\Tests\Models\Car;
+use Parental\Tests\Models\Cat;
+use Parental\Tests\Models\Dog;
 use Parental\Tests\Models\Train;
 use Parental\Tests\Models\Vehicle;
 use Parental\Tests\Observers\CarObserver;
@@ -92,5 +95,14 @@ class ParentsObserveChildrenTest extends TestCase
 
         $car = Car::create();
         $this->assertEquals(1, $car->boot_count);
+    }
+
+    /** @test */
+    public function registering_events_in_parent_trait_only_triggers_once()
+    {
+        Cat::create();
+        Dog::create();
+
+        $this->assertEquals(2, Animal::$created);
     }
 }

--- a/tests/Models/Animal.php
+++ b/tests/Models/Animal.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Parental\Tests\Models;
+
+use Parental\HasChildren;
+
+class Animal extends CountedModel
+{
+    use HasChildren;
+
+    protected $childTypes = [
+        'cat' => Cat::class,
+        'dog' => Dog::class,
+    ];
+}

--- a/tests/Models/Cat.php
+++ b/tests/Models/Cat.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Parental\Tests\Models;
+
+use Parental\HasParent;
+
+class Cat extends Animal
+{
+    use HasParent;
+}

--- a/tests/Models/CountedModel.php
+++ b/tests/Models/CountedModel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Parental\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Parental\Tests\Traits\CountsCreatedModels;
+
+class CountedModel extends Model
+{
+    use CountsCreatedModels;
+
+    static int $created = 0;
+
+    protected $fillable = [
+        'type', 'name',
+    ];
+
+    protected $guarded = [];
+}

--- a/tests/Models/Dog.php
+++ b/tests/Models/Dog.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Parental\Tests\Models;
+
+use Parental\HasParent;
+
+class Dog extends Animal
+{
+    use HasParent;
+}

--- a/tests/Observers/ModelCreatedObserver.php
+++ b/tests/Observers/ModelCreatedObserver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Parental\Tests\Observers;
+
+use Parental\Tests\Models\CountedModel;
+
+class ModelCreatedObserver
+{
+    /**
+     * Handle the created event.
+     *
+     * @param  CountedModel  $model
+     *
+     * @return void
+     */
+    public function created(CountedModel $model)
+    {
+        $model::$created++;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -106,6 +106,13 @@ class TestCase extends BaseTestCase
             $table->string('skill_level')->nullable();
             $table->timestamps();
         });
+
+        Schema::create('animals', function ($table) {
+            $table->increments('id');
+            $table->string('type')->nullable();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
     }
 
     protected function getEnvironmentSetUp($app)

--- a/tests/Traits/CountsCreatedModels.php
+++ b/tests/Traits/CountsCreatedModels.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Parental\Tests\Traits;
+
+use Parental\Tests\Observers\ModelCreatedObserver;
+
+trait CountsCreatedModels
+{
+    static int $created = 0;
+
+    public static function bootCountsCreatedModels(): void
+    {
+        static::observe(new ModelCreatedObserver());
+    }
+}


### PR DESCRIPTION
Came across this issue when using `owen-it/laravel-auditing`.
My `Model` class uses the `Auditable` trait, but the events are registered twice because `parentIsBooting` only accounts for traits used by the parent class itself, to solve this problem I created a static array for parent classes and added an alternative `isset` verification, similar to the preexisting `$parentBootMethods` logic.